### PR TITLE
Remove Bearman from 2023, Fix his path from Ferrari to Haas

### DIFF
--- a/data/drivers.csv
+++ b/data/drivers.csv
@@ -291,10 +291,7 @@ DEV,Nyck de Vries,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,williams,alphataur
 LAW,Liam Lawson,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,alphatauri,,
 PIA,Oscar Piastri,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,mclaren,mclaren,mclaren
 SAR,Logan Sargeant,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,williams,williams,
-BEA,Oliver Bearman,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,ferrari,,
-BEA,Oliver Bearman,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,ferrari,
-BEA,Oliver Bearman,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,haas,
-BEA,Oliver Bearman,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,haas
+BEA,Oliver Bearman,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,ferrari+haas,haas
 DOO,Jack Doohan,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,alpine
 BOR,Gabriel Bortoleto,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,kicksauber
 HAD,Isack Hadjar,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,visa


### PR DESCRIPTION
Oliver Bearman was shown to be a part of Ferrari in 2023, which is incorrect as he was a rookie back then. His path from Ferrari in 2024 to Haas in 2024 and then 2025 wasn't connected, did that.